### PR TITLE
chore: reference README in package

### DIFF
--- a/src/BigO.Validation/BigO.Validation.csproj
+++ b/src/BigO.Validation/BigO.Validation.csproj
@@ -18,12 +18,12 @@
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<Authors>Omar Besiso</Authors>
 		<Version>9.0.1</Version>
-		<PackageReadmeFile>Readme.md</PackageReadmeFile>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<Resource Include="..\..\Readme.md">
+		<Resource Include="..\..\README.md">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>


### PR DESCRIPTION
## Summary
- fix package metadata to reference README.md

## Testing
- `dotnet pack src/BigO.Validation/BigO.Validation.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689604c4864c832a822e6c5071bf65a5