### PR TITLE
Remove DoesNotReturnIf from NotNull guards

### DIFF
--- a/src/BigO.Validation/Guard.MaxLength.cs
+++ b/src/BigO.Validation/Guard.MaxLength.cs
@@ -36,7 +36,7 @@ public static partial class Guard
     ///     length is greater than <paramref name="maxLength" />.
     /// </exception>
     /// <remarks>
-    ///     Use <see cref="NotNull{T}(T?,string,string?)" /> or
+    ///     Use <see cref="NotNull{T}(T,string,string?)" /> or
     ///     <see cref="NotNullOrEmpty(string?,string,string?)" /> when you also need
     ///     to forbid <see langword="null" /> or empty strings.
     /// </remarks>

--- a/src/BigO.Validation/Guard.MinLength.cs
+++ b/src/BigO.Validation/Guard.MinLength.cs
@@ -36,7 +36,7 @@ public static partial class Guard
     ///     length is less than <paramref name="minLength" />.
     /// </exception>
     /// <remarks>
-    ///     Use <see cref="NotNull{T}(T?,string,string?)" /> or
+    ///     Use <see cref="NotNull{T}(T,string,string?)" /> or
     ///     <see cref="NotNullOrEmpty(string?,string,string?)" /> when you also need
     ///     to forbid <see langword="null" /> or empty strings.
     /// </remarks>

--- a/src/BigO.Validation/Guard.NotNull.cs
+++ b/src/BigO.Validation/Guard.NotNull.cs
@@ -44,7 +44,7 @@ public static partial class Guard
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNull]
     public static T NotNull<T>(
-        [NotNull] [DoesNotReturnIf(true)] T? value,
+        [NotNull] T? value,
         [CallerArgumentExpression(nameof(value))]
         string paramName = "",
         string? exceptionMessage = null)
@@ -75,7 +75,7 @@ public static partial class Guard
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IEnumerable<T> NotNull<T>(
-        [NotNull] [DoesNotReturnIf(true)] IEnumerable<T>? collection,
+        [NotNull] IEnumerable<T>? collection,
         [CallerArgumentExpression(nameof(collection))]
         string paramName = "",
         string? exceptionMessage = null)

--- a/src/BigO.Validation/PropertyGuard.NotNull.cs
+++ b/src/BigO.Validation/PropertyGuard.NotNull.cs
@@ -30,7 +30,7 @@ public static partial class PropertyGuard
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNull]
     public static T NotNull<T>(
-        [NotNull] [DoesNotReturnIf(true)] T? value,
+        [NotNull] T? value,
         [CallerMemberName] string propertyName = "",
         string? exceptionMessage = null)
         => Guard.NotNull(value, propertyName, exceptionMessage);
@@ -53,7 +53,7 @@ public static partial class PropertyGuard
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IEnumerable<T> NotNull<T>(
-        [NotNull] [DoesNotReturnIf(true)] IEnumerable<T>? collection,
+        [NotNull] IEnumerable<T>? collection,
         [CallerMemberName] string propertyName = "",
         string? exceptionMessage = null)
         => Guard.NotNull(collection, propertyName, exceptionMessage);

--- a/src/BigO.Validation/PropertyGuard.Positive.cs
+++ b/src/BigO.Validation/PropertyGuard.Positive.cs
@@ -5,24 +5,46 @@ using System.Runtime.CompilerServices;
 
 namespace BigO.Validation;
 
-/// <summary>
-///     Guard helpers specialised for property setters and initialisers.
-/// </summary>
-public static partial class PropertyGuard
-{
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T Positive<T>(
-        T value,
-        [CallerMemberName] string propertyName = "",
-        string? exceptionMessage = null)
-        where T : INumber<T>
-        => Guard.Positive(value, propertyName, exceptionMessage);
+    /// <summary>
+    ///     Guard helpers specialised for property setters and initialisers.
+    /// </summary>
+    public static partial class PropertyGuard
+    {
+        /// <summary>
+        ///     Ensures a numeric property value is greater than zero.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the property.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="propertyName">
+        ///     Name of the property being validated, captured automatically via
+        ///     <see cref="CallerMemberNameAttribute" /> when omitted.
+        /// </param>
+        /// <param name="exceptionMessage">Optional custom message.</param>
+        /// <returns>The validated positive value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T Positive<T>(
+            T value,
+            [CallerMemberName] string propertyName = "",
+            string? exceptionMessage = null)
+            where T : INumber<T>
+            => Guard.Positive(value, propertyName, exceptionMessage);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static T NonNegative<T>(
-        T value,
-        [CallerMemberName] string propertyName = "",
-        string? exceptionMessage = null)
-        where T : INumber<T>
-        => Guard.NonNegative(value, propertyName, exceptionMessage);
-}
+        /// <summary>
+        ///     Ensures a numeric property value is zero or greater.
+        /// </summary>
+        /// <typeparam name="T">Numeric type of the property.</typeparam>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="propertyName">
+        ///     Name of the property being validated, captured automatically via
+        ///     <see cref="CallerMemberNameAttribute" /> when omitted.
+        /// </param>
+        /// <param name="exceptionMessage">Optional custom message.</param>
+        /// <returns>The validated non-negative value.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T NonNegative<T>(
+            T value,
+            [CallerMemberName] string propertyName = "",
+            string? exceptionMessage = null)
+            where T : INumber<T>
+            => Guard.NonNegative(value, propertyName, exceptionMessage);
+    }


### PR DESCRIPTION
## Summary
- drop DoesNotReturnIf(true) from Guard.NotNull and PropertyGuard.NotNull to avoid analyzer noise
- tidy XML documentation and add missing comments to keep build warning-free

## Testing
- `dotnet build src/BigO.Validation.sln`


------
https://chatgpt.com/codex/tasks/task_e_689604c9257c832a808cd9f75204358c